### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
+## Deprecation warning
+
+`movie-cli` is no longer being actively maintained, and does not function due to OMDBAPI (the API used for retrieving movie information) being made a paid service.
+
+If anyone is interested in finding an alternative API to use then please feel free to submit a Pull Request!
+
+---
+
 # movie-cli
 A CLI for getting information about a movies and comparing two movies
 
 ```
 npm i -g movie-cli
 ```
+
 ```
 movie Into The Wild                // For infomation about a movie
 movie Into The Wild :: Wild        // For comparing two movies


### PR DESCRIPTION
As outlined in #2 and commented on in #3, the application no longer works due to the OMDBAPI becoming a paid service.

This PR adds a deprecation notice at the top of the README to alert potential users that, at least for right now, the application is no longer functional.

/cc @mayankchd 